### PR TITLE
fix: correct getting attribute value in rspec matcher

### DIFF
--- a/lib/normalizy/rspec/matcher.rb
+++ b/lib/normalizy/rspec/matcher.rb
@@ -58,7 +58,7 @@ module Normalizy
         else
           @subject.send :"#{@attribute}=", @from
 
-          @subject[@attribute] == @to
+          @subject.send(@attribute) == @to
         end
       end
 


### PR DESCRIPTION
sometimes `@subject[@attribute]` return `nil` instead correct value and we can recieved so message

```
Failure/Error: it { is_expected.to normalizy(:service_email).from('Email@example.com').to 'email@example.com' }

       expected: "email@example.com"
            got: "email@example.com"
```