### PR TITLE
Add truncate filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,17 @@ normalizy :name, with: { strip: { side: :both } }
 
 As you can see, the rules can be passed as Symbol/String or as Hash if it has options.
 
+### Truncate
+
+Remove excedent string part from a gived limit.
+
+```ruby
+normalizy :description, with: { truncate: { limit: 10 } }
+
+'Once upon a time in a world far far away'
+# 'Once upon '
+```
+
 ## Multiple Filters
 
 You can normalize with a couple of filters at once:

--- a/lib/normalizy/config.rb
+++ b/lib/normalizy/config.rb
@@ -29,7 +29,8 @@ module Normalizy
         number:  Normalizy::Filters::Number,
         percent: Normalizy::Filters::Percent,
         slug:    Normalizy::Filters::Slug,
-        strip:   Normalizy::Filters::Strip
+        strip:   Normalizy::Filters::Strip,
+        truncate: Normalizy::Filters::Truncate,
       }
     end
   end

--- a/lib/normalizy/filters/truncate.rb
+++ b/lib/normalizy/filters/truncate.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Normalizy
+  module Filters
+    module Truncate
+      module_function
+
+      def call(input, options = {})
+        return input unless options[:limit].is_a?(Integer)
+        return input unless input.is_a?(String)
+
+        input[0, options[:limit]]
+      end
+    end
+  end
+end

--- a/spec/normalizy/config/add_spec.rb
+++ b/spec/normalizy/config/add_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe Normalizy::Config, '#add' do
       number:    Normalizy::Filters::Number,
       percent:   Normalizy::Filters::Percent,
       slug:      Normalizy::Filters::Slug,
-      strip:     Normalizy::Filters::Strip
+      strip:     Normalizy::Filters::Strip,
+      truncate:  Normalizy::Filters::Truncate,
     )
   end
 end

--- a/spec/normalizy/config/initialize_spec.rb
+++ b/spec/normalizy/config/initialize_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe Normalizy::Config, 'filters' do
       number:  Normalizy::Filters::Number,
       percent: Normalizy::Filters::Percent,
       slug:    Normalizy::Filters::Slug,
-      strip:   Normalizy::Filters::Strip
+      strip:   Normalizy::Filters::Strip,
+      truncate: Normalizy::Filters::Truncate,
     )
   end
 end

--- a/spec/normalizy/filters/truncate_spec.rb
+++ b/spec/normalizy/filters/truncate_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Normalizy::Filters::Truncate do
+  context 'when :limit options is not given' do
+    it { expect(subject.call('miss')).to eq 'miss' }
+  end
+
+  context 'when :limit options is not a number' do
+    it { expect(subject.call('miss', limit: "wrong")).to eq 'miss' }
+  end
+
+  context 'when input value is not a string' do
+    it { expect(subject.call(10)).to eq 10 }
+  end
+
+  context 'when :limit is given' do
+    it { expect(subject.call('abcdefghijklmnopkrstuvxyz', limit: 3)).to eq 'abc' }
+  end
+end


### PR DESCRIPTION
I created that to resolve database limit for my models too.

I imagine when someone exceeds the "rule" for length (on varchar/string context) my model have filter the data.

For that moment the new filter needs which user give the `limit` value. But I imagine make `255` a default value but that is more applicable for database context (when we creates a varchar column with default value).

That's it :smiley: 